### PR TITLE
Instructions and builder for windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build
 builddir
 .cache
+subprojects

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ ninja -C build
 ./build/asunapixel
 ```
 Instructions for building on windows available here:
-[building-on-windows.md](./docs/building-on-windows)
+[building-on-windows.md](./docs/building-on-windows.md)

--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ meson build --buildtype=release
 ninja -C build
 ./build/asunapixel
 ```
+Instructions for building on windows available here:
+[building-on-windows.md](./docs/building-on-windows)

--- a/builder.cmd
+++ b/builder.cmd
@@ -1,0 +1,41 @@
+@echo off
+SETLOCAL
+
+@REM In case the user hasn't chosen the build profile
+set "param2=%~2"
+if "%param2%"=="" set "param2=release"
+
+@REM The switch statement:
+goto CASE_%1
+
+@REM User hasn't specified any parameters
+:CASE_
+	echo Usage:
+	echo 	builder -b
+	echo 		Builds asunapixel
+	echo 	builder -r
+	echo 		Runs asunapixel (only if built already)
+	echo 	builder -br
+	echo 		Builds and then runs asunapixel
+	goto END_CASE
+:CASE_build
+:CASE_-b
+	call :build %param2%
+	goto END_CASE
+:CASE_-br
+	call :build %param2%
+	cd build
+	call asunapixel
+	goto END_CASE
+:CASE_run
+:CASE_-r
+	cd build
+	call asunapixel
+	goto END_CASE
+:END_CASE
+	exit /B %ERRORLEVEL%
+
+:build
+	meson build --buildtype=%~1
+	ninja -C build
+	exit /B 0

--- a/docs/building-on-windows.md
+++ b/docs/building-on-windows.md
@@ -1,0 +1,22 @@
+# Instructions for building asunapixel on windows.
+
+## Ensure following software is installed:
+- [`Python` (with `pip`)](https://www.python.org/downloads/)
+- [`msys2`](https://www.msys2.org/)
+
+## Installing needed software
+- Go into your msys2 `MSYS2 MinGW x64` terminal
+- Update everything with `pacman -Syu`
+- Install needed packages with `pacman -S mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-meson mingw-w64-x86_64-ninja mingw-w64-x86_64-sfml`
+- Change the `PATH` environment variable to feature `C:\msys64\mingw64\bin`
+
+## Building the project
+- Go into the command line
+- Change the directory to the `asunapixel`'s one
+- Build and run with the builder tool:
+	- `./builer -br` in powershell
+	- `builder -br` in cmd
+- Alternatively build and run on your own:
+	- Prebuild with `meson build --buildtype=release`
+	- Build with `ninja -C build`
+	- If compilation and linking succeeded, run with `./build/asunapixel` in powershell or `cd build` then `asunapixel.exe` in cmd.


### PR DESCRIPTION
- Added `builder.cmd` as an alternative to `builder.sh` for windows devs / users.
- Added instructions on how to build the project on windows.

I hope everything looks good enough. :D